### PR TITLE
Fix error when no location is set for a slider

### DIFF
--- a/Observer/AddBlock.php
+++ b/Observer/AddBlock.php
@@ -85,8 +85,12 @@ class AddBlock implements ObserverInterface
             $output         = $observer->getTransport()->getOutput();
 
             foreach ($this->helperData->getActiveSliders() as $slider) {
-                $locations = explode(',', $slider->getLocation());
+               if($slider->getLocation()){
+                   
+                   $locations = explode(',', $slider->getLocation());
+             
                 foreach ($locations as $value) {
+                    
                     list($pageType, $location) = explode('.', $value);
                     if (($fullActionName === $pageType || $pageType === 'allpage') &&
                         strpos($location, $type) !== false
@@ -104,6 +108,9 @@ class AddBlock implements ObserverInterface
                         }
                     }
                 }
+                   
+               }
+              
             }
 
             $observer->getTransport()->setOutput($output);


### PR DESCRIPTION
When no position is set for the slider, we get error 
1 exception(s):
Exception #0 (Exception): Notice: Undefined offset: 1 in /home/joachim/public_html/vendor/mageplaza/module-banner-slider/Observer/AddBlock.php on line 90