### PR TITLE
add empty location value so that admin can unset the option if necessary

### DIFF
--- a/Model/Config/Source/Location.php
+++ b/Model/Config/Source/Location.php
@@ -57,6 +57,9 @@ class Location implements ArrayInterface
     {
         $options = [
             [
+                'label' => 'Manually', 'value' => ''
+            ],
+            [
                 'label' => __('All Page'),
                 'value' => [
                     [


### PR DESCRIPTION
At the moment if you set a location for a slider, you cannot unset it.