### PR TITLE
Widget needs to implement blockInterface

### DIFF
--- a/Block/Widget.php
+++ b/Block/Widget.php
@@ -22,12 +22,13 @@
 namespace Mageplaza\BannerSlider\Block;
 
 use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+use Magento\Widget\Block\BlockInterface;
 
 /**
  * Class Widget
  * @package Mageplaza\BannerSlider\Block
  */
-class Widget extends Slider
+class Widget extends Slider implements BlockInterface
 {
     /**
      * @return array|bool|AbstractCollection


### PR DESCRIPTION
is an answer to error (Invalid Block Type: Mageplaza \BannerSlider\Block\Widget::class does not exist) referenced in issue  https://github.com/mageplaza/magento-2-banner-slider/issues/24