### PR TITLE
Adding IdentityInterface (cache invalidation)

### DIFF
--- a/Block/Slider.php
+++ b/Block/Slider.php
@@ -27,14 +27,17 @@ use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
 use Magento\Framework\Stdlib\DateTime\DateTime;
 use Magento\Framework\View\Element\Template;
+use Magento\Framework\DataObject\IdentityInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Mageplaza\BannerSlider\Helper\Data as bannerHelper;
+use Mageplaza\BannerSlider\Model\Banner;
+use Mageplaza\BannerSlider\Model\Slider;
 
 /**
  * Class Slider
  * @package Mageplaza\BannerSlider\Block
  */
-class Slider extends Template
+class Slider extends Template implements IdentityInterface
 {
     /**
      * @type bannerHelper
@@ -141,5 +144,28 @@ class Slider extends Template
     public function getBannerOptions()
     {
         return $this->helperData->getBannerOptions($this->getSlider());
+    }
+    
+    /**
+     * Return unique cache ID(s)
+     * to trigger cache invalidation when banner and slider are changed
+     *
+     * @return string[]
+     */
+    public function getIdentities()
+    {
+        $identities = [];
+
+        /** @var Slider $slider */
+        if($slider = $this->getSlider()) {
+            $identities = array_merge($identities, $slider->getIdentities());
+        }
+
+        /** @var Banner $banner */
+        foreach ($this->getBannerCollection() as $banner) {
+            $identities = array_merge($identities, $banner->getIdentities());
+        }
+
+        return $identities;
     }
 }

--- a/Model/Banner.php
+++ b/Model/Banner.php
@@ -26,6 +26,7 @@ use Magento\Framework\Model\AbstractModel;
 use Magento\Framework\Model\Context;
 use Magento\Framework\Model\ResourceModel\AbstractResource;
 use Magento\Framework\Registry;
+use Magento\Framework\DataObject\IdentityInterface;
 use Mageplaza\BannerSlider\Model\Config\Source\Image as configImage;
 use Mageplaza\BannerSlider\Model\ResourceModel\Slider\Collection;
 use Mageplaza\BannerSlider\Model\ResourceModel\Slider\CollectionFactory as sliderCollectionFactory;
@@ -55,7 +56,7 @@ use Mageplaza\BannerSlider\Model\ResourceModel\Banner as ResourceBanner;
  * @method Banner setAffectedSliderIds(array $ids)
  * @method bool getAffectedSliderIds()
  */
-class Banner extends AbstractModel
+class Banner extends AbstractModel implements IdentityInterface
 {
     /**
      * Cache tag

--- a/Model/Slider.php
+++ b/Model/Slider.php
@@ -26,6 +26,7 @@ use Magento\Framework\Model\AbstractModel;
 use Magento\Framework\Model\Context;
 use Magento\Framework\Model\ResourceModel\AbstractResource;
 use Magento\Framework\Registry;
+use Magento\Framework\DataObject\IdentityInterface;
 use Mageplaza\BannerSlider\Model\ResourceModel\Banner\Collection;
 use Mageplaza\BannerSlider\Model\ResourceModel\Banner\CollectionFactory;
 
@@ -49,7 +50,7 @@ use Mageplaza\BannerSlider\Model\ResourceModel\Banner\CollectionFactory;
  * @method Slider setAffectedBannerIds(array $ids)
  * @method bool getAffectedBannerIds()
  */
-class Slider extends AbstractModel
+class Slider extends AbstractModel implements IdentityInterface
 {
     /**
      * Cache tag


### PR DESCRIPTION
Hello,

I noticed some slider/banner data weren't showing changes right away after save (had to flush cache manually)

Models needs to implement IdentityInterface in order to get the native cache invalidation (`$_cacheTag` and `function getIdentities()` are well implemented already but see `vendor/magento/framework/App/Cache/Tag/Strategy/Identifier.php:24`)

`Block/Slider.php` : 
Views that display that content needs, according to doc, to implement the IdentityInterface
[Dev Docs #invalidate-public-content](https://devdocs.magento.com/guides/v2.3/extension-dev-guide/cache/page-caching/public-content.html#invalidate-public-content)

