### PR TITLE
fix slider multiselect missing closing div

### DIFF
--- a/Block/Adminhtml/Banner/Edit/Tab/Render/Slider.php
+++ b/Block/Adminhtml/Banner/Edit/Tab/Render/Slider.php
@@ -83,7 +83,7 @@ class Slider extends Multiselect
         $html .= '<input name="banner[sliders_ids]" data-bind="value: value" style="display: none"/>';
         $html .= '<!-- ko template: elementTmpl --><!-- /ko -->';
         $html .= '<!-- /ko -->';
-        $html .= '</div>';
+        $html .= '</div></div>';
 
         $html .= $this->getAfterElementHtml();
 


### PR DESCRIPTION
adding a missing closing div tag to Sliders field in banner edit form
Issue #47 