### PR TITLE
$slider->getLocation() can be null

### DIFF
--- a/Observer/AddBlock.php
+++ b/Observer/AddBlock.php
@@ -85,22 +85,24 @@ class AddBlock implements ObserverInterface
             $output         = $observer->getTransport()->getOutput();
 
             foreach ($this->helperData->getActiveSliders() as $slider) {
-                $locations = array_filter(explode(',', $slider->getLocation()));
-                foreach ($locations as $value) {
-                    list($pageType, $location) = explode('.', $value);
-                    if (($fullActionName === $pageType || $pageType === 'allpage') &&
-                        strpos($location, $type) !== false
-                    ) {
-                        $content = $layout->createBlock(Slider::class)
-                            ->setSlider($slider)
-                            ->toHtml();
+                if (!empty($slider->getLocation())) {
+                    $locations = array_filter(explode(',', $slider->getLocation()));
+                    foreach ($locations as $value) {
+                        list($pageType, $location) = explode('.', $value);
+                        if (($fullActionName === $pageType || $pageType === 'allpage') &&
+                            strpos($location, $type) !== false
+                        ) {
+                            $content = $layout->createBlock(Slider::class)
+                                ->setSlider($slider)
+                                ->toHtml();
 
-                        if (strpos($location, 'top') !== false) {
-                            $output = "<div id=\"mageplaza-bannerslider-block-before-{$type}-{$slider->getId()}\">
-                                        $content</div>" . $output;
-                        } else {
-                            $output .= "<div id=\"mageplaza-bannerslider-block-after-{$type}-{$slider->getId()}\">
-                                        $content</div>";
+                            if (strpos($location, 'top') !== false) {
+                                $output = "<div id=\"mageplaza-bannerslider-block-before-{$type}-{$slider->getId()}\">
+                                            $content</div>" . $output;
+                            } else {
+                                $output .= "<div id=\"mageplaza-bannerslider-block-after-{$type}-{$slider->getId()}\">
+                                            $content</div>";
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
If $slider->getLocation() is null, explode returns a NOT empty array with one entry "".
Then, ```list($pageType, $location) = explode('.', $value);``` throws an error.