### PR TITLE
Prevents error when slider lacks position setting

### DIFF
--- a/Observer/AddBlock.php
+++ b/Observer/AddBlock.php
@@ -87,20 +87,22 @@ class AddBlock implements ObserverInterface
             foreach ($this->helperData->getActiveSliders() as $slider) {
                 $locations = array_filter(explode(',', $slider->getLocation()));
                 foreach ($locations as $value) {
-                    list($pageType, $location) = explode('.', $value);
-                    if (($fullActionName === $pageType || $pageType === 'allpage') &&
-                        strpos($location, $type) !== false
-                    ) {
-                        $content = $layout->createBlock(Slider::class)
-                            ->setSlider($slider)
-                            ->toHtml();
+                    if (stripos($value, '.') !== false) {
+                        list($pageType, $location) = explode('.', $value);
+                        if (($fullActionName === $pageType || $pageType === 'allpage') &&
+                            strpos($location, $type) !== false
+                        ) {
+                            $content = $layout->createBlock(Slider::class)
+                                ->setSlider($slider)
+                                ->toHtml();
 
-                        if (strpos($location, 'top') !== false) {
-                            $output = "<div id=\"mageplaza-bannerslider-block-before-{$type}-{$slider->getId()}\">
-                                        $content</div>" . $output;
-                        } else {
-                            $output .= "<div id=\"mageplaza-bannerslider-block-after-{$type}-{$slider->getId()}\">
-                                        $content</div>";
+                            if (strpos($location, 'top') !== false) {
+                                $output = "<div id=\"mageplaza-bannerslider-block-before-{$type}-{$slider->getId()}\">
+                                    $content</div>" . $output;
+                            } else {
+                                $output .= "<div id=\"mageplaza-bannerslider-block-after-{$type}-{$slider->getId()}\">
+                                    $content</div>";
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
If you don't select a slider position setting the module signals an error, "Undefined index" and this is because it's trying to do `list($pageType, $location) = explode('.', $value);` when `$value` doesn't contain a dot. I added a IF-condition to prevents the error