### PR TITLE
dateFormat in slider edit based on admin user locale

### DIFF
--- a/Block/Adminhtml/Slider/Edit/Tab/Slider.php
+++ b/Block/Adminhtml/Slider/Edit/Tab/Slider.php
@@ -123,6 +123,7 @@ class Slider extends Generic implements TabInterface
         $form = $this->_formFactory->create();
         $form->setHtmlIdPrefix('slider_');
         $form->setFieldNameSuffix('slider');
+        $dateFormat = $this->_localeDate->getDateFormat(\IntlDateFormatter::SHORT);
         $fieldset = $form->addFieldset('base_fieldset', [
             'legend' => __('Slider Information'),
             'class' => 'fieldset-wide'
@@ -188,7 +189,7 @@ class Slider extends Generic implements TabInterface
             'name' => 'from_date',
             'label' => __('Display from'),
             'title' => __('Display from'),
-            'date_format' => 'M/d/yyyy',
+            'date_format' => $dateFormat,
             'input_format' => DateTime::DATE_INTERNAL_FORMAT,
             'timezone' => false
         ]);
@@ -197,7 +198,7 @@ class Slider extends Generic implements TabInterface
             'name' => 'to_date',
             'label' => __('Display to'),
             'title' => __('Display to'),
-            'date_format' => 'M/d/yyyy',
+            'date_format' => $dateFormat,
             'input_format' => DateTime::DATE_INTERNAL_FORMAT,
             'timezone' => false
         ]);


### PR DESCRIPTION
I`ve been facing an issue with this extension for a long time ( 2 years ) where users with different locale are editing the start/end date of the banners. 

Examples to test:

Make your admin user with the country option Bulgaria for example.
Create a slider with start date 12 Feb 2021 using js datepicker.
As expected from the hardcoded format and the locale: 
  - the date used is 12/02/2021 which is 2 Dec 2021 and the banner does not fire up.

I am just contributing my fix to the issue for the community.