### PR TITLE
#91: Missing class Zend_Filter_Input saving a slider in M2.4.6 / PHP 8.1

### DIFF
--- a/Controller/Adminhtml/Slider/Save.php
+++ b/Controller/Adminhtml/Slider/Save.php
@@ -34,8 +34,7 @@ use Magento\Framework\Stdlib\DateTime\Filter\Date;
 use Mageplaza\BannerSlider\Controller\Adminhtml\Slider;
 use Mageplaza\BannerSlider\Model\SliderFactory;
 use RuntimeException;
-use Zend_Filter_Input;
-
+use Magento\Framework\Filter\FilterInput;
 /**
  * Class Save
  * @package Mageplaza\BannerSlider\Controller\Adminhtml\Slider
@@ -188,7 +187,12 @@ class Save extends Slider
      */
     protected function _filterData($data)
     {
-        $inputFilter = new Zend_Filter_Input(['from_date' => $this->_dateFilter,], [], $data);
+        $filterValues = ['from_date' => $this->_dateFilter];
+        $inputFilter = new FilterInput(
+            $filterValues,
+            [],
+            $data
+        );
         $data = $inputFilter->getUnescaped();
 
         if (isset($data['responsive_items'])) {


### PR DESCRIPTION
#91: Missing class Zend_Filter_Input saving a slider in M2.4.6 / PHP 8.1