### PR TITLE
Fix layout issue with Hyva theme

### DIFF
--- a/view/frontend/layout/hyva_default.xml
+++ b/view/frontend/layout/hyva_default.xml
@@ -20,7 +20,7 @@
  * @license     https://www.mageplaza.com/LICENSE.txt
  */
 -->
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="2columns-left" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
         <remove src="Mageplaza_Core::css/owl.carousel.css"/>
         <remove src="Mageplaza_Core::css/owl.theme.css"/>


### PR DESCRIPTION
Certain pages such as Customer Login, Register, and others unexpectedly switch to a 2-column layout with a left sidebar.

This happend because layout="2columns-left" defined in hyva_default.xml file.

To fix the issue i've removed the "2columns-left" from the code.